### PR TITLE
1.13 anvil

### DIFF
--- a/src/org/jmc/TextureExporter.java
+++ b/src/org/jmc/TextureExporter.java
@@ -216,7 +216,6 @@ public class TextureExporter {
 			ZipEntry entry = null;
 			while ((entry = zis.getNextEntry()) != null) {
 				String entryName = entry.getName();
-				Log.debug(entryName + " found in resource pack");
 				if (entryName.startsWith("assets/minecraft/textures/block"))
 					found1_13AssetsDir = true;
 				else if (entryName.startsWith("assets/minecraft/textures/blocks"))

--- a/src/org/jmc/TextureExporter.java
+++ b/src/org/jmc/TextureExporter.java
@@ -8,16 +8,19 @@ import java.awt.image.ImagingOpException;
 import java.awt.image.WritableRaster;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import java.util.zip.ZipFile;
 
 import javax.imageio.ImageIO;
 import javax.xml.xpath.XPath;
@@ -64,24 +67,42 @@ public class TextureExporter {
 		return ImageIO.read(file);
 	}
 
-	private static BufferedImage loadImageFromZip(File zipfile, String imagePath) throws IOException {
+	private static List<String> loadImageListFromZip(File zipfile) throws IOException {
 		ZipInputStream zis = null;
+		ZipEntry entry = null;
+		Log.debug("\tStarted zip LIST stream");
+		List<String> texlist = new ArrayList<String>();
 		try {
 			zis = new ZipInputStream(new FileInputStream(zipfile));
-
-			ZipEntry entry = null;
 			while ((entry = zis.getNextEntry()) != null)
-				if (!entry.isDirectory() && entry.getName().equals(imagePath))
-					break;
-
-			if (entry == null)
-				throw new IOException("Couldn't find " + imagePath + " in " + zipfile.getName());
-
-			BufferedImage result = ImageIO.read(zis);
-			return result;
+				if (!entry.isDirectory()){
+					texlist.add(entry.getName());
+				}
 		} finally {
 			if (zis != null)
 				zis.close();
+		}
+		return texlist;
+	}
+
+	private static BufferedImage loadImageFromZip(File zipfile, String imagePath) throws IOException {
+		InputStream zis = null;
+		ZipFile zf = null;
+		BufferedImage result = null;
+		try {
+			zf = new ZipFile(zipfile);
+			ZipEntry entry = null;
+			entry = zf.getEntry(imagePath);
+			if (entry.getName() == null)
+				throw new IOException("Couldn't find " + imagePath + " in " + zipfile.getName());
+			zis = zf.getInputStream(entry);
+			result = ImageIO.read(zis);
+		} finally {
+			if (zf != null)
+				zf.close();
+			if (zis != null)
+				zis.close();
+			return result;
 		}
 	}
 
@@ -177,7 +198,7 @@ public class TextureExporter {
 	/**
 	 * Looks inside the given zip file to determine the format of the texture
 	 * pack.
-	 * 
+	 *
 	 * @param zipfile
 	 * @return Constant indicating texture pack format.
 	 * @throws IOException
@@ -195,6 +216,7 @@ public class TextureExporter {
 			ZipEntry entry = null;
 			while ((entry = zis.getNextEntry()) != null) {
 				String entryName = entry.getName();
+				Log.debug(entryName + " found in resource pack");
 				if (entryName.startsWith("assets/minecraft/textures/block"))
 					found1_13AssetsDir = true;
 				else if (entryName.startsWith("assets/minecraft/textures/blocks"))
@@ -205,9 +227,9 @@ public class TextureExporter {
 					foundTerrainPng = true;
 			}
 
-			return	found1_13AssetsDir ? FORMAT_1_13 : 
-					found1_6AssetsDir ? FORMAT_1_6 : 
-					foundBlocksDir ? FORMAT_1_5 : 
+			return	found1_13AssetsDir ? FORMAT_1_13 :
+					found1_6AssetsDir ? FORMAT_1_6 :
+					foundBlocksDir ? FORMAT_1_5 :
 					foundTerrainPng ? FORMAT_PRE_1_5 :
 					FORMAT_INVALID;
 		} finally {
@@ -220,7 +242,7 @@ public class TextureExporter {
 	 * Reads the configuration file "texsplit.conf". Private method to retrieve
 	 * textures from a texturepack in a list. This was extracted into a separate
 	 * method so it can be reused between the split and merge methods.
-	 * 
+	 *
 	 * @param texturePack
 	 * @param scale
 	 * @param progress
@@ -275,6 +297,9 @@ public class TextureExporter {
 		Document doc = Xml.loadDocument(confFile);
 		XPath xpath = XPathFactory.newInstance().newXPath();
 
+		// create a memory copy of zip file names, to avoid duplicate zipstreams
+		List<String> texlist = loadImageListFromZip(zipfile);
+
 		NodeList fileNodes = (NodeList) xpath.evaluate("/texsplit/file", doc, XPathConstants.NODESET);
 		for (int i = 0; i < fileNodes.getLength(); i++) {
 			Node fileNode = fileNodes.item(i);
@@ -287,11 +312,11 @@ public class TextureExporter {
 				throw new Exception("In " + confFilePath + ": 'file' tag is missing required attribute 'name'.");
 
 			BufferedImage image = null;
-			
 			try {
 				image = loadImage(zipfile, source, fileName);
 			} catch (Exception e) {
-				Log.info("Error loading image: " + e.getMessage());
+				Log.info("Error loading image (" + fileName + "): "+ e.getMessage());
+				continue;
 			}
 
 			int width = image.getWidth() / Integer.parseInt(cols, 10);
@@ -307,7 +332,7 @@ public class TextureExporter {
 				String repeating_str = Xml.getAttribute(texNode, "repeating");
 				if (repeating_str != null)
 					repeating = repeating_str.toLowerCase().equals("true");
-				
+
 				boolean luma = false;
 				String luma_str = Xml.getAttribute(texNode, "luma");
 				if (luma_str != null)
@@ -355,13 +380,13 @@ public class TextureExporter {
 				else {
 					Log.debug("Creating Texture for: " + texName);
 					Texture texture2 = new Texture(texName, texture, repeating, luma);
-					
+
 					if (diffuse) {
 						Log.debug("Writing Diffuse Texture: " + texName);
 						ImageIO.write(texture2.image, "png", new File(destination, texture2.name + ".png"));
 					}
-					
-					if (alphas) {
+
+					if (alphas){
 						try {
 							convertToAlpha(texture2.image);
 							Log.debug("Writing Alpha Texture: " + texture2.name + "_a.png");
@@ -370,13 +395,13 @@ public class TextureExporter {
 							Log.info("Cannot save alpha for: " + texture2.name + " (" + e.getMessage() + ")");
 						}
 					}
-					
-					if (exportNormal) {
+
+					if (exportNormal && texlist.contains(fileName.replace(".png", "_n.png"))) {
 						try {
 							Log.debug("Trying normal map");
-							
+
 							BufferedImage imageN = loadImage(zipfile, source, fileName.replace(".png", "_n.png"));
-							
+
 							Log.debug("Found Normal. Creating Buffered Texture.");
 							BufferedImage textureN = new BufferedImage(width, height, imageN.getType());
 							imageN.getSubimage(colPos * width, rowPos * height, width, height).copyData(textureN.getRaster());
@@ -387,23 +412,23 @@ public class TextureExporter {
 									Log.info("Cannot scale image: " + texName + "_n (" + e.getMessage() + ")");
 								}
 							}
-							
+
 							Log.debug("Creating Normal Texture. " + texName + "_n");
 							Texture texture2N = new Texture(texName + "_n", textureN, repeating, false);
 							Log.debug("Writing Normal Texture. " + texture2N.name);
 							ImageIO.write(texture2N.image, "png", new File(destination, texture2N.name + ".png"));
-							
+
 						} catch (Exception e) {
 							Log.info("Error loading normal texture: " + e.getMessage());
 						}
 					}
-					
-					if (exportSpecular) {
+
+					if (exportSpecular && texlist.contains(fileName.replace(".png", "_s.png"))) {
 						try {
 							Log.debug("Trying specular map");
-							
+
 							BufferedImage imageS = loadImage(zipfile, source, fileName.replace(".png", "_s.png"));
-							
+
 							Log.debug("Found Specular. Creating Buffered Texture.");
 							BufferedImage textureS = new BufferedImage(width, height, imageS.getType());
 							imageS.getSubimage(colPos * width, rowPos * height, width, height).copyData(textureS.getRaster());
@@ -418,12 +443,12 @@ public class TextureExporter {
 							Texture texture2S = new Texture(texName + "_s", textureS, repeating, false);
 							Log.debug("Writing Specular Texture. " + texture2S.name);
 							ImageIO.write(texture2S.image, "png", new File(destination, texture2S.name + ".png"));
-							
+
 						} catch (Exception e) {
 							Log.info("Error loading specular image: " + e.getMessage());
 						}
 					}
-					
+
 				}
 
 			}
@@ -431,7 +456,7 @@ public class TextureExporter {
 			if (progress != null)
 				progress.setProgress((i + 1) / (float) fileNodes.getLength());
 		}
-		
+
 		if(merging)
 			return ret;
 		else
@@ -446,17 +471,17 @@ public class TextureExporter {
 			image = loadImageFromFile(new File(Filesystem.getDatafilesDir(), fileName));
 		else
 			image = loadImageFromFile(new File(fileName));
-		
+
 		if (image.getType() != BufferedImage.TYPE_4BYTE_ABGR)
 			image = convertImageType(image);
-		
+
 		return image;
 	}
 
 	/**
 	 * Reads a Minecraft texture pack and splits the individual block textures
 	 * into .png images.
-	 * 
+	 *
 	 * @param destination
 	 *            Directory to place the output files.
 	 * @param texturePack
@@ -490,7 +515,8 @@ public class TextureExporter {
 				throw new RuntimeException("Cannot create texture directory!");
 		}
 
-/*		List<Texture> textures = */getTextures(texturePack, scale, progress, diffuse, alphas, false, normals, specular, destination);
+/*		List<Texture> textures = */
+		getTextures(texturePack, scale, progress, diffuse, alphas, false, normals, specular, destination);
 
 //		float texnum = textures.size();
 //		float count = 0;
@@ -517,7 +543,7 @@ public class TextureExporter {
 	 * Reads a Minecraft texture pack and splits the individual block textures
 	 * into separate images then merges them into a single file containing all
 	 * the textures.
-	 * 
+	 *
 	 * @param destination
 	 *            Directory to place the output files. They will be called
 	 *            "texture.png" and "texture_a.png"
@@ -526,8 +552,8 @@ public class TextureExporter {
 	 *            default textures.
 	 * @param scale
 	 *            Scaling to apply to textures.
-	 * @param diffuse 
-	 *            Whether to export separate diffuse maps. 
+	 * @param diffuse
+	 *            Whether to export separate diffuse maps.
 	 * @param alphas
 	 *            Whether to export separate alpha masks.
 	 * @param normals
@@ -629,7 +655,7 @@ public class TextureExporter {
 
 		BufferedImage textureimage = new BufferedImage(wmax, hmax, BufferedImage.TYPE_4BYTE_ABGR);
 		Graphics2D gtex = textureimage.createGraphics();
-		
+
 		BufferedImage lumaimage = new BufferedImage(wmax, hmax, BufferedImage.TYPE_4BYTE_ABGR);
 		Graphics2D gtexluma = lumaimage.createGraphics();
 
@@ -646,7 +672,7 @@ public class TextureExporter {
 						int sy = rect.y + y * rect.height;
 						gtex.drawImage(texture.image, sx, sy, sx + rect.width, sy + rect.height, 0, 0, rect.width,
 								rect.height, null);
-						
+
 						if(lumas)
 							if(texture.luma)
 								gtexluma.drawImage(texture.image, sx, sy, sx + rect.width, sy + rect.height, 0, 0, rect.width,
@@ -668,7 +694,7 @@ public class TextureExporter {
 		ImageIO.write(textureimage, "png", new File(destination, "texture.png"));
 		if(lumas)
 			ImageIO.write(lumaimage, "png", new File(destination, "texture_luma.png"));
-		
+
 		if (alphas) {
 			try {
 				convertToAlpha(textureimage);


### PR DESCRIPTION
Textures are exported faster now due to:

1) Only exporting norm or spec maps if the file is known to exist in the zip file ahead of time (a memory copy of the zip contents is made up front, so that the zip file is opened once, instead of always opening a new zip stream even if the texture does not exist)
2) By switching to directly loading the asset from the zip file instead of iterating over all files in the zip until a path matches (ie using `getEntry(imagePath)` instead of a loop of `getNextEntry()`)
3) By skipping image sets where the default diffuse image is not present at all, whereas before if there was an error in loading the default diffuse image, it will still attempt to continue with the following operations. This is done via the `continue` [line here](https://github.com/TheDuckCow/j-mc-2-obj/commit/6cd8ccbc0f958a795c5259b30f90e530b7e27470#diff-c0f117834c826067be0241bcfc066d8fR319).

I did some tests on some local resource packs, ones with and without normal/spec, and compared the output (ie number of files in the texture output folder and matching names) against the most recently released code, but worth checking on some more packs or doing your own spot checks.

This is in response to the issue thread here: https://github.com/jmc2obj/j-mc-2-obj/issues/122