### PR TITLE
Fix preview panel dragging experience

### DIFF
--- a/src/org/jmc/gui/PreviewPanel.java
+++ b/src/org/jmc/gui/PreviewPanel.java
@@ -63,7 +63,7 @@ public class PreviewPanel extends JPanel implements MouseMotionListener, MouseWh
 	/**
 	 * Offset of the map, as set by dragging the map around.
 	 */
-	private int shift_x,shift_y;
+	private float shift_x,shift_y;
 	/**
 	 * Zoom level of the map.
 	 */
@@ -449,8 +449,8 @@ public class PreviewPanel extends JPanel implements MouseMotionListener, MouseWh
 	{
 		Rectangle ret=new Rectangle();
 
-		ret.x=(-shift_x/64)-1;
-		ret.y=(-shift_y/64)-1;
+		ret.x=((int)-shift_x/64)-1;
+		ret.y=((int)-shift_y/64)-1;
 		ret.width=(int) Math.ceil((getWidth()/zoom_level)/64.0)+1;
 		ret.height=(int) Math.ceil((getHeight()/zoom_level)/64.0)+1;
 
@@ -771,8 +771,8 @@ public class PreviewPanel extends JPanel implements MouseMotionListener, MouseWh
 
 		if(moving_map)
 		{		
-			shift_x+=(x-last_x)/zoom_level;
-			shift_y+=(y-last_y)/zoom_level;
+			shift_x+=(float)(x-last_x)/zoom_level;
+			shift_y+=(float)(y-last_y)/zoom_level;
 
 			last_x=x;
 			last_y=y;


### PR DESCRIPTION
This pull request do a very tiny change, but critical to the user experience.
Preview panel dragging is clunky if zoom level above 1. The higher the zoom level, the worser it is. This issue fixed by changing datatype that shifting the chunk position in preview panel from int to float. This happens probably rounding error and such.

Here we are creating a variable that representing a vector (displacement) that shift the chunk image on preview panel. If we use int for that, we would not be able to use intermediate values such as 1.2, 3.6 etc so more precision needed, and that's why we should use float instead of int for this particular variable

![edited](https://user-images.githubusercontent.com/93080026/201633789-a4794fce-0c0d-4b03-982f-9acb96f3f67a.gif)
