### PR TITLE
Set FileChooser to show hidden files

### DIFF
--- a/src/org/jmc/gui/ExportWindow.java
+++ b/src/org/jmc/gui/ExportWindow.java
@@ -606,6 +606,7 @@ public class ExportWindow extends JmcFrame implements ProgressCallback {
 						super.approveSelection();
 					}
 				};
+				jfc.setFileHidingEnabled(false);
 				jfc.setFileFilter(new FileNameExtensionFilter("Obj files", "obj", "OBJ", "Obj"));
 				int retval = jfc.showDialog(ExportWindow.this, Messages.getString("TexsplitDialog.SEL_EXPORT_DEST"));
 				if (retval != JFileChooser.APPROVE_OPTION)
@@ -620,6 +621,7 @@ public class ExportWindow extends JmcFrame implements ProgressCallback {
 			public void actionPerformed(ActionEvent arg0) {
 
 				JFileChooser jfcRP = new JFileChooser(MainWindow.settings.getLastExportPath());
+				jfcRP.setFileHidingEnabled(false);
 				jfcRP.setFileFilter(new FileNameExtensionFilter("Zip files", "zip", "ZIP", "Zip"));
 				int retval = jfcRP.showDialog(ExportWindow.this, Messages.getString("TexsplitDialog.SEL_RP"));
 				if (retval != JFileChooser.APPROVE_OPTION)
@@ -655,6 +657,7 @@ public class ExportWindow extends JmcFrame implements ProgressCallback {
 					}
 				};
 
+				jfc.setFileHidingEnabled(false);
 				jfc.setFileFilter(new FileNameExtensionFilter("Obj files", "obj", "OBJ", "Obj"));
 				retval = jfc.showDialog(ExportWindow.this, Messages.getString("TexsplitDialog.SEL_EXPORT_DEST"));
 				if (retval != JFileChooser.APPROVE_OPTION)
@@ -757,6 +760,8 @@ public class ExportWindow extends JmcFrame implements ProgressCallback {
 					}
 
 				};
+
+				jfc.setFileHidingEnabled(false);
 
 				if (Options.useLastSaveLoc && !prefs.get("LAST_EXPORT_PATH", "not here").equals("not here")
 						&& new File(prefs.get("LAST_EXPORT_PATH", "not here")).exists()) {

--- a/src/org/jmc/gui/MainPanel.java
+++ b/src/org/jmc/gui/MainPanel.java
@@ -480,6 +480,7 @@ public class MainPanel extends JPanel {
 			public void actionPerformed(ActionEvent arg0) {
 
 				JFileChooser jfc = new JFileChooser(MainWindow.settings.getLastVisitedDir());
+				jfc.setFileHidingEnabled(false);
 				jfc.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 				if (jfc.showDialog(MainPanel.this,
 						Messages.getString("MainPanel.CHOOSE_SAVE_FOLDER")) == JFileChooser.APPROVE_OPTION) {

--- a/src/org/jmc/gui/Settings.java
+++ b/src/org/jmc/gui/Settings.java
@@ -301,6 +301,7 @@ public class Settings extends JmcFrame implements WindowListener, ChangeListener
 			public void actionPerformed(ActionEvent e) {
 				JFileChooser jfc = new JFileChooser(MainWindow.settings.getLastExportPath());
 				//jfc.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+				jfc.setFileHidingEnabled(false);
 				jfc.addChoosableFileFilter(new FileFilter() {
 					@Override public String getDescription() {return "Extracted pack.mcmeta";}
 					@Override public boolean accept(File f) {return f.isDirectory() || f.getName().equals("pack.mcmeta");}


### PR DESCRIPTION
All file choosers should now show hidden files. Hopefully I didn't miss one.

This is especially annoying because .minecraft is a hidden folder. So you can't navigate into .minecraft, which is obviously a slight issue for non-standard installations

Might merge conflict with #217, whichever gets merged first I'll merge the upstream back for the other one, hope I notice

Best, Lena

(Hope it's fine I didn't make an issue, it was so little code and so little work, and I wanted it as a fork regardless)