### PR TITLE
Fix calculating rescale multiplier

### DIFF
--- a/src/org/jmc/models/Registry.java
+++ b/src/org/jmc/models/Registry.java
@@ -137,7 +137,7 @@ public class Registry extends BlockModel {
 		}
 		float scale = 1;
 		if (rot.rescale) {
-			scale = (float) (0.5-Math.abs(Math.cos(Math.toRadians(2*rot.angle)))*0.5+1);
+			scale = (float) (1f / Math.cos(Math.toRadians(Math.abs(rot.angle))));
 		}
 		switch (rot.axis) {
 		case "x":


### PR DESCRIPTION
resolve #294 

Visually, it’s a very minor change and seems like nothing has changed, but for me, it’s an incredibly significant fix...

---

**Affected blocks by this changes**

* Azalea
* Bushes
* Coral
* Dripleaf
* Fire, including Campfire
* Flowers, including potted plants
* Grasses
* Mangrove Propagule
* Pointed Dripstone
* Raised Rails (important)
* Sea pickles
* Stem
* Tripwire Hook

These blocks become smaller a bit.